### PR TITLE
Fix SSL and host header

### DIFF
--- a/lib/rack/delegate/configuration.rb
+++ b/lib/rack/delegate/configuration.rb
@@ -7,7 +7,7 @@ module Rack
         config.actions
       end
 
-      attr_reader :actions
+      attr_reader :actions, :ssl_options
 
       def initialize
         @actions = []
@@ -15,10 +15,11 @@ module Rack
         @rewriter = Rewriter.new
         @changer = Rewriter.new
         @timeout = NetworkErrorResponse
+        @ssl_options = {use_ssl: true}
       end
 
       def from(pattern, to:, constraints: nil)
-        action = Action.new(pattern, Delegator.new(to, @rewriter, @changer, @timeout))
+        action = Action.new(pattern, Delegator.new(to, @rewriter, @changer, @timeout, @ssl_options))
         action = Rack::Timeout.new(action) if timeout?
 
         constraints = Array(constraints).concat(@constraints)
@@ -44,6 +45,10 @@ module Rack
       def timeout(response_object = nil, &block)
         @timeout = response_object if response_object
         @timeout = block if block
+      end
+
+      def ssl_options(options)
+        @ssl_options.merge!(options)
       end
 
       private

--- a/lib/rack/delegate/delegator.rb
+++ b/lib/rack/delegate/delegator.rb
@@ -3,11 +3,12 @@ require 'timeout_errors'
 module Rack
   module Delegate
     class Delegator
-      def initialize(url, uri_rewriter, net_http_request_rewriter, timeout_response)
+      def initialize(url, uri_rewriter, net_http_request_rewriter, timeout_response, ssl_options)
         @url = URI(url)
         @uri_rewriter = uri_rewriter
         @net_http_request_rewriter = net_http_request_rewriter
         @timeout_response = timeout_response
+        @ssl_options = ssl_options
       end
 
       def call(env)
@@ -26,7 +27,11 @@ module Rack
       private
 
       def net_http_options
-        [@url.host, @url.port, use_ssl: @url.scheme == 'https']
+        if @url.scheme == 'https'
+          [@url.host, @url.port, @ssl_options]
+        else
+          [@url.host, @url.port]
+        end
       end
 
       def convert_to_rack_response(http_response)

--- a/lib/rack/delegate/delegator.rb
+++ b/lib/rack/delegate/delegator.rb
@@ -26,7 +26,7 @@ module Rack
       private
 
       def net_http_options
-        [@url.host, @url.port, https: @url.scheme == 'https']
+        [@url.host, @url.port, use_ssl: @url.scheme == 'https']
       end
 
       def convert_to_rack_response(http_response)

--- a/lib/rack/delegate/net_http_request_builder.rb
+++ b/lib/rack/delegate/net_http_request_builder.rb
@@ -8,6 +8,10 @@ module Rack
         CONTENT_TYPE
       ).freeze
 
+      IGNORED_HEADERS = %w(
+        HTTP_HOST
+      ).freeze
+
       def build
         net_http_request_class.new(url).tap do |net_http_request|
           delegate_rack_headers_to(net_http_request)
@@ -52,6 +56,7 @@ module Rack
       def headers_from_rack_request(rack_request)
         rack_request.env
           .select  { |key, _| key.start_with?('HTTP_') || CONTENT_HEADERS.include?(key) }
+          .reject { |key, _| IGNORED_HEADERS.include?(key) }
           .collect { |key, value| [key.sub(/^HTTP_/, '').tr('_', '-'), value] }
       end
     end

--- a/test/rack/delegate/net_http_request_builder_test.rb
+++ b/test/rack/delegate/net_http_request_builder_test.rb
@@ -7,6 +7,7 @@ module Rack
         'REQUEST_METHOD' => 'POST',
         'REMOTE_ADDR' => '123.123.123.123',
         'HTTP_X_CUSTOM_HEADER' => '42',
+        'HTTP_HOST' => 'example.com',
         'CONTENT_TYPE' => 'application/json',
         'CONTENT_LENGTH' => '2',
         'rack.input' => StringIO.new('42')
@@ -18,6 +19,10 @@ module Rack
 
       test "delegates all the Rack request headers" do
         assert_equal @@env['HTTP_X_CUSTOM_HEADER'], net_http_request['X-CUSTOM-HEADER']
+      end
+
+      test "delegates all the Rack request headers but HTTP_HOST to avoid virtual host issues" do
+        assert_nil net_http_request['HOST']
       end
 
       test "delegates all the content headers" do


### PR DESCRIPTION
- SSL did not work at all
- add option to work with invalid certificates (on test environments)
- do not propagate the "Host" header because it confuses web servers with virtual host support
