### PR TITLE
do not propagate Connection header. Closes #ADIBLO-779

### DIFF
--- a/lib/rack/delegate/net_http_request_builder.rb
+++ b/lib/rack/delegate/net_http_request_builder.rb
@@ -9,7 +9,7 @@ module Rack
       ).freeze
 
       IGNORED_HEADERS = %w(
-        HTTP_HOST
+        HTTP_HOST HTTP_CONNECTION
       ).freeze
 
       def build

--- a/test/rack/delegate/net_http_request_builder_test.rb
+++ b/test/rack/delegate/net_http_request_builder_test.rb
@@ -8,6 +8,7 @@ module Rack
         'REMOTE_ADDR' => '123.123.123.123',
         'HTTP_X_CUSTOM_HEADER' => '42',
         'HTTP_HOST' => 'example.com',
+        'HTTP_CONNECTION' => 'Keep-Alive',
         'CONTENT_TYPE' => 'application/json',
         'CONTENT_LENGTH' => '2',
         'rack.input' => StringIO.new('42')
@@ -21,8 +22,12 @@ module Rack
         assert_equal @@env['HTTP_X_CUSTOM_HEADER'], net_http_request['X-CUSTOM-HEADER']
       end
 
-      test "delegates all the Rack request headers but HTTP_HOST to avoid virtual host issues" do
+      test "delegates the Rack request headers but not HTTP_HOST to avoid virtual host issues" do
         assert_nil net_http_request['HOST']
+      end
+
+      test "delegates the Rack request headers but not HTTP_CONNECTION to avoid problems with persistent connections" do
+        assert_nil net_http_request['CONNECTION']
       end
 
       test "delegates all the content headers" do


### PR DESCRIPTION
- avoid persistent (“Keep-Alive”) connections
- those persistent connections caused problems with some servers
- it’s not a good idea to use persistent connections within the proxy anyway