### PR TITLE
Introduces callbacks for header manipulation outside of the delegation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .tags
+.byebug_history

--- a/lib/rack/delegate.rb
+++ b/lib/rack/delegate.rb
@@ -13,10 +13,12 @@ module Rack
     autoload :Dispatcher, 'rack/delegate/dispatcher'
 
     class << self
-      attr_accessor :network_error_response
+      attr_accessor :network_error_response, :default_headers_callback
     end
     self.network_error_response = NetworkErrorResponse
 
+    # Waits for an Array to be returned as part of the header used 
+    # for delegating. Array needs to be [ [ HEADER_NAME, HEADER_VALUE]* ]
     def self.configure(&block)
       dispatcher = Dispatcher.configure(&block)
 
@@ -31,6 +33,15 @@ module Rack
           end
         end
       end
+    end
+
+    #
+    # Will execute the Rack::Delegate.default_headers_callback if set.
+    # This expects an hash to be returned to be used as default_headers
+    # in the forwarded request. This method expects the request env as 
+    # parameter
+    def self.default_headers(env)
+      Rack::Delegate.default_headers_callback && Rack::Delegate.default_headers_callback.call(env) || {}
     end
   end
 end

--- a/lib/rack/delegate/net_http_request_builder.rb
+++ b/lib/rack/delegate/net_http_request_builder.rb
@@ -58,6 +58,11 @@ module Rack
           .select  { |key, _| key.start_with?('HTTP_') || CONTENT_HEADERS.include?(key) }
           .reject { |key, _| IGNORED_HEADERS.include?(key) }
           .collect { |key, value| [key.sub(/^HTTP_/, '').tr('_', '-'), value] }
+          .push(*headers_from_default_headers(rack_request.env))
+      end
+
+      def headers_from_default_headers(env)
+        Rack::Delegate.default_headers(env).to_a.map { |key,value| [ key.to_s.upcase, value ] } || []
       end
     end
   end

--- a/test/rack/delegate/net_http_request_builder_test.rb
+++ b/test/rack/delegate/net_http_request_builder_test.rb
@@ -11,7 +11,8 @@ module Rack
         'HTTP_CONNECTION' => 'Keep-Alive',
         'CONTENT_TYPE' => 'application/json',
         'CONTENT_LENGTH' => '2',
-        'rack.input' => StringIO.new('42')
+        'rack.input' => StringIO.new('42'),
+        'action_dispatch.request_id' => '42'
       )
 
       @@request = Rack::Request.new(@@env)
@@ -41,6 +42,11 @@ module Rack
 
       test "strips /prefix from the request" do
         assert_equal 'http://example.com/foo/42', net_http_request.uri.to_s
+      end
+
+      test "header_callbacks as part of header" do
+        Rack::Delegate.default_headers_callback = Proc.new { |env| { 'X-Request-Id' => env['action_dispatch.request_id'] } }
+        assert_equal '42', net_http_request['X-REQUEST-ID']
       end
 
       def net_http_request


### PR DESCRIPTION
Could be used for forwarding headers from source env to destination env.
Example could be
* X-Request-Id
* X-Forward

Closes #DEVOPS-748
/cc @csmuc 