### PR TITLE
Remove header transfer-encoding in response header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,7 @@ gemspec
 gem 'bundler', '~> 1.9'
 gem 'rake', '~> 10.0'
 
-gem 'minitest'
+group :test do
+  gem 'minitest'
+  gem 'webmock'
+end

--- a/lib/rack/delegate/delegator.rb
+++ b/lib/rack/delegate/delegator.rb
@@ -45,6 +45,7 @@ module Rack
       def normalize_headers_for(http_response)
         http_response.to_hash.tap do |headers|
           headers.delete('status')
+          headers.delete('transfer-encoding')
 
           # Since Ruby 2.1 Net::HTTPHeader#to_hash returns the value as an
           # array of values and not a string. Try to coerce it for 2.0 support.

--- a/test/rack/delegate/delegator_test.rb
+++ b/test/rack/delegate/delegator_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+require 'webmock/minitest'
+
+module Rack
+  module Delegate
+    class DelegatorTest < Minitest::Test
+      @@url = 'http://example.com/prefix/foo/42'
+      @@env = Rack::MockRequest.env_for(@@url,
+        'REQUEST_METHOD' => 'POST',
+        'REMOTE_ADDR' => '123.123.123.123',
+        'HTTP_X_CUSTOM_HEADER' => '42',
+        'HTTP_HOST' => 'example.com',
+        'HTTP_CONNECTION' => 'Keep-Alive',
+        'CONTENT_TYPE' => 'application/json',
+        'CONTENT_LENGTH' => '2',
+        'rack.input' => StringIO.new('42')
+      )
+
+      @@request = Rack::Request.new(@@env)
+      @@uri_rewriter = Rewriter.new { |u| u.path = u.path.gsub('/prefix', ''); u }
+      @@request_rewriter = Rewriter.new
+      @@error_response = NetworkErrorResponse
+      @@delegator = Delegator.new(@@url, @@uri_rewriter, @@request_rewriter, @@error_response, {})
+
+      def net_http_stub_request
+        stub_request(:post, "http://example.com/foo/42").
+          with(:body => "42",
+               :headers => {'Content-Length'=>'2', 'Content-Type'=>'application/json', 'X-Custom-Header'=>'42'}).
+          to_return(:status => 200, :body => '', :headers => { 'x-request-id': '42', 'transfer-encoding': 'chunked', 'status': '400' })
+      end
+
+      test "returns response with proper header" do
+        net_http_stub_request
+        assert_equal(["200", { 'x-request-id' => '42' }, [] ], @@delegator.call(@@env))
+      end
+
+      test "will not return transfer-encoding header in response" do
+        net_http_stub_request
+        assert_nil @@delegator.call(@@env)[1]['transfer-encoding']
+      end
+    end
+  end
+end


### PR DESCRIPTION
This removes chunked encoding from the response header as the data is already completely downloaded at the proxy. Forwarding this header makes the client crazy waiting for more data but everything is already there.

I think this is a workaround and flow control in HTTP/1.1 should be properly supported in rack::delegate but currently I don't know how. But this workaround doesn't make rack::delegate worse IMHO.

/cc @csmuc 
FYI @meyer-fidor-com (I don't know if our proxy would also be impacted)

Closes #ADIBLO-3377